### PR TITLE
Removing duplicate definition of call method

### DIFF
--- a/vars/shStage.groovy
+++ b/vars/shStage.groovy
@@ -3,9 +3,3 @@ def call(command) {
     sh command
   }
 }
-
-def call(name, command) {
-  catchStage(name) {
-    sh command
-  }
-}


### PR DESCRIPTION
Was reading your repo and I noticed your call method was duplicated. This seems like a mistake?